### PR TITLE
Listings behave like figures when it comes to placement

### DIFF
--- a/versatile-apa/lib.typ
+++ b/versatile-apa/lib.typ
@@ -248,15 +248,13 @@
     size: 10pt,
   )
 
-  show raw.where(block: true): set par(leading: 1em)
+show raw.where(block: true): it => {
+  set par(leading: 1em)
+  set align(start)
+  box(it, width: 100%)
+}
 
   set math.equation(numbering: "(1)")
-
-  show figure.where(kind: raw): it => {
-    set align(left)
-    it.caption
-    it.body
-  }
 
   show quote.where(block: true): set block(spacing: double-spacing)
 

--- a/versatile-apa/template/sections/computer-code.typ
+++ b/versatile-apa/template/sections/computer-code.typ
@@ -12,6 +12,7 @@ The template has some support for raw/computer code, but if further customizatio
       print("Hello, World!")
   ```,
   caption: [Python code block],
+  placement: none
 )
 
 === Non-figure code block


### PR DESCRIPTION
With this change, code listings behave like figures: the placement argument works and the code is not separated from its legend. As I am not a pro in typst, feel free to modify and even not accept it :)