### PR TITLE
Add Serbian (Latin and Cyrillic) translations to get-terms

### DIFF
--- a/versatile-apa/utils/languages.typ
+++ b/versatile-apa/utils/languages.typ
@@ -76,6 +76,28 @@
       "Addendum": "Addendum",
       "Note": "Notitie",
     )
+  } else if language in ("sr_Latn", "sr") {
+      (
+        "and": "i",
+        "Author Note": "Napomena autora",
+        "Abstract": "Apstrakt",
+        "Keywords": "Ključne reči",
+        "Appendix": "Dodatak",
+        "Annex": "Prilog",
+        "Addendum": "Dopuna",
+        "Note": "Napomena",
+      )
+  } else if language == "sr_Cyrl" {
+      (
+        "and": "и",
+        "Author Note": "Напомена аутора",
+        "Abstract": "Апстракт",
+        "Keywords": "Кључне речи",
+        "Appendix": "Додатак",
+        "Annex": "Прилог",
+        "Addendum": "Допуна",
+        "Note": "Напомена",
+      )
   } else {
     panic("Unsupported language:", language)
   }


### PR DESCRIPTION
This PR adds support for Serbian in both Latin (sr_Latn, sr) and Cyrillic (sr_Cyrl) scripts to the get-terms function.