### PR TITLE
Use counter from level 1 heading for apa-figure-numbering (appendix)

### DIFF
--- a/versatile-apa/utils/apa-figure.typ
+++ b/versatile-apa/utils/apa-figure.typ
@@ -3,7 +3,7 @@
 
 #let apa-figure-numbering(n) = {
   let header-counter = counter(heading).get().first()
-  let queried-heading = query(selector(heading).before(here())).last().numbering
+  let queried-heading = query(selector(heading.where(level: 1)).before(here())).last().numbering
   if queried-heading == none {
     queried-heading = "A"
   }


### PR DESCRIPTION
I stumbled upon this problem when using subsections in my appendices.

`apa-figure-numbering` is used in appendix for labelling figures with A1, A2, B1 etc. But if a figure is within a subsection in the appendix (that is normally not numbered) it will get a confusing numbering (like 2.1). 

This explicitly looks for the previous level 1 heading so that all figures within for example appendix A and its subsections are labelled A1, A2, etc.

Sorry there are no test cases or anything for this. I am not sure how you want to approach pull requests. However, this worked for my current document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined figure numbering computation for improved accuracy in APA-formatted documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jassielof/typst-templates/pull/53)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->